### PR TITLE
querystring test: Fix description

### DIFF
--- a/test/part-1/parse-querystring/parse-querystring.js
+++ b/test/part-1/parse-querystring/parse-querystring.js
@@ -34,7 +34,7 @@ describe("Test the function parse", function() {
         done();
     });
 
-    it("parse('http://lnu.se?key='); should return {}", function(done) {
+    it("parse('http://lnu.se?key='); should return {key : ''}", function(done) {
         var obj = {key: ""};
         expect(qsParser.parse("http://lnu.se?key=")).to.eql(obj);
         done();


### PR DESCRIPTION
It looks like both the fourth and sixth test should expect the same result.
