### PR TITLE
jshint: Remove "es5: true"

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -29,7 +29,6 @@
   "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
   "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
   "eqnull"        : false,     // true: Tolerate use of `== null`
-  "es5"           : true,     // true: Allow ES5 syntax (ex: getters and setters)
   "esnext"        : true,     // true: Allow ES.next (ES6) syntax (ex: `const`)
   "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
   // (ex: `for each`, multiple try/catch, function expression…)


### PR DESCRIPTION
I get "ES5 option is now set per default"-errors from jshint. It seems to be because "es5: true" is already the default in version +2.0.0: http://jshint.com/blog/2013-05-07/2-0-0/
https://jslinterrors.com/es5-option-is-now-set-per-default

With the patch I no longer recieve the error message.

Oh, and I don't know what the second line modification is all about. I created the pull request from the github webinterface.
